### PR TITLE
README maven badge references wrong artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You can use this code with the Google Authenticator mobile app or the Authy mobi
 
 * See the [wikipedia page about TOTP](http://en.wikipedia.org/wiki/Time-based_One-time_Password_Algorithm).	
 * Code available from the [git repository](https://github.com/j256/two-factor-auth).  [![CircleCI](https://circleci.com/gh/j256/two-factor-auth.svg?style=svg)](https://circleci.com/gh/j256/two-factor-auth) [![CodeCov](https://img.shields.io/codecov/c/github/j256/two-factor-auth.svg)](https://codecov.io/github/j256/two-factor-auth/)
-* Maven packages are published via [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.j256.cloudwatchlogbackappender/cloudwatchlogbackappender/badge.svg?style=flat-square)](https://maven-badges.herokuapp.com/maven-central/com.j256.two-factor-auth/two-factor-auth/)
+* Maven packages are published via [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.j256.two-factor-auth/two-factor-auth/badge.svg?style=flat-square)](https://maven-badges.herokuapp.com/maven-central/com.j256.two-factor-auth/two-factor-auth/)
 
 ## To get this to work you:
 


### PR DESCRIPTION
It looks like the maven badge was added by copying from another repostiory. The link URL was changed but the image URL was not, this resulted in the incorrect version number being displayed.